### PR TITLE
Support for slicing after the current offset

### DIFF
--- a/src/clever-buffer-common.coffee
+++ b/src/clever-buffer-common.coffee
@@ -34,4 +34,8 @@ class CleverBuffer
   trim: =>
     @buffer.slice 0, @offset
 
+  slice: (start, end) =>
+    realEnd = if end then @offset + end else @buffer.length
+    @buffer.slice @offset + (start or 0), realEnd
+
 module.exports = CleverBuffer

--- a/test/common.spec.coffee
+++ b/test/common.spec.coffee
@@ -1,0 +1,32 @@
+should              = require 'should'
+CleverBufferReader   = require "#{SRC}/clever-buffer-reader"
+
+describe 'CleverBufferCommon', ->
+
+  buf = new Buffer [
+      0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9
+  ]
+
+  it 'can slice from the current offset until the end', ->
+    cleverBuffer = new CleverBufferReader buf
+    cleverBuffer.getUInt8().should.eql 0xa1
+    cleverBuffer.getUInt8().should.eql 0xa2
+    cleverBuffer.slice().toString('hex').should.eql 'a3a4a5a6a7a8a9'
+
+  it 'can slice from a given index (after the offset) until the end', ->
+    cleverBuffer = new CleverBufferReader buf
+    cleverBuffer.getUInt8().should.eql 0xa1
+    cleverBuffer.getUInt8().should.eql 0xa2
+    cleverBuffer.slice(2).toString('hex').should.eql 'a5a6a7a8a9'
+
+  it 'can slice from between two indexes (after the offset)', ->
+    cleverBuffer = new CleverBufferReader buf
+    cleverBuffer.getUInt8().should.eql 0xa1
+    cleverBuffer.getUInt8().should.eql 0xa2
+    cleverBuffer.slice(2, 5).toString('hex').should.eql 'a5a6a7'
+
+  it 'cannot slice past the end', ->
+    cleverBuffer = new CleverBufferReader buf
+    cleverBuffer.getUInt8().should.eql 0xa1
+    cleverBuffer.getUInt8().should.eql 0xa2
+    cleverBuffer.slice(2, 20).toString('hex').should.eql 'a5a6a7a8a9'


### PR DESCRIPTION
Mirrors the native [Buffer.slice](http://nodejs.org/api/buffer.html#buffer_buf_slice_start_end)
- `slice() = [ offset .. buffer.length ]`
- `slice(start) = [ offset+start .. buffer.length ]`
- `slice(start, end) = [ offset+start .. offset+end ]`
