### PR TITLE
Pin ref package to v1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepublish": "npm test && npm run compile"
   },
   "dependencies": {
-    "ref": "~1.3.2"
+    "//": "there is a known issue with ref:1.3.5 and certain versions of node",
+    "ref": "1.3.4"
   },
   "devDependencies": {
     "cli-table": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "compile": "coffee --output target --compile src",
     "prepublish": "npm test && npm run compile"
   },
+  "//": "there is a known issue with ref:1.3.5 and certain versions of node",
   "dependencies": {
-    "//": "there is a known issue with ref:1.3.5 and certain versions of node",
     "ref": "1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The ref dependency doesn't work on a lot of our current versions of node. 
When we update ref to 1.3.5 or higher we should add an 'engines' field to package.json.


This is the problem that occurs with ref@1.3.5.
```
# nvm use 6.9.1
Now using node v6.9.1 (npm v3.10.8)

# node -e "require('ref'); console.log('success');"
/Users/barkert/test/node_modules/ref/lib/ref.js:1455
  if (inspect.name === 'refinspect') {
             ^

TypeError: Cannot read property 'name' of undefined
```

However, it works just fine on later versions of node.
```
# nvm use 6.11.2
Now using node v6.11.2 (npm v3.10.10)

# node -e "require('ref'); console.log('success');"
success
```