### PR TITLE
Leading zeros should not parse strings as octal numbers

### DIFF
--- a/src/clever-buffer-writer.coffee
+++ b/src/clever-buffer-writer.coffee
@@ -47,6 +47,9 @@ class CleverBufferWriter extends CleverBuffer
 
   writeUInt64: (value, _offset) ->
     offset = _offset ? @offset
+    # ref treats leading zeros as denoting octal numbers, so we want to strip
+    # them out to prevent this behaviour
+    value = value.replace /^0+(\d)/, '$1'
     if @bigEndian
       ref.writeUInt64BE(@buffer, offset, value)
     else
@@ -55,6 +58,10 @@ class CleverBufferWriter extends CleverBuffer
 
   writeInt64: (value, _offset) ->
     offset = _offset ? @offset
+    # ref treats leading zeros as denoting octal numbers, so we want to strip
+    # them out to prevent this behaviour.
+    # Also, ref treats '-0123' as a negative octal
+    value = value.replace /^(-?)0+(\d)/, '$1$2'
     if @bigEndian
       ref.writeInt64BE(@buffer, offset, value)
     else

--- a/test/clever-buffer-reader.spec.coffee
+++ b/test/clever-buffer-reader.spec.coffee
@@ -1,27 +1,6 @@
 should             = require 'should'
 CleverBufferReader = require "#{SRC}/clever-buffer-reader"
-
-# cartesianProduct takes an object of arrays and creates an array of objects
-# with every combination of values from each array.
-# example:
-# cartesianProduct({ a: [1,2,3], b: [false, true] })
-# -> [ { a: 1, b: false },
-#      { a: 1, b: true  },
-#      { a: 2, b: false },
-#      { a: 2, b: true  },
-#      { a: 3, b: false },
-#      { a: 3, b: true  } ]
-cartesianProduct = (arg) ->
-  acc = [{}]
-  for own key, xs of arg
-    acc_ = []
-    for a in acc
-      for x in xs
-        r = Object.assign {}, a
-        r[key] = x
-        acc_.push r
-    acc = acc_
-  acc
+specHelper         = require './spec-helper'
 
 describe 'CleverBufferReader', ->
 
@@ -179,13 +158,13 @@ describe 'CleverBufferReader', ->
     should.equal(cleverBuffer.getUInt8(), 1)
     should.equal(typeof cleverBuffer.getUInt8(), 'undefined')
 
-  testCases =
+  testCases = specHelper.cartesianProduct
     size:      [1, 2, 4, 8]
     unsigned:  [false, true]
     bigEndian: [false, true]
     offset:    [undefined, 20]
 
-  for testCase in (cartesianProduct testCases)
+  for testCase in testCases
     do ({size, unsigned, bigEndian, offset} = testCase) ->
       it "should throw RangeError when reading past the length for #{JSON.stringify testCase}", ->
         buf = new Buffer (offset ? 0) + size - 1
@@ -197,7 +176,7 @@ describe 'CleverBufferReader', ->
         f = if unsigned then "getUInt#{size*8}" else "getInt#{size*8}"
         (-> cleverBuffer[f](offset)).should.throw RangeError
 
-  for testCase in (cartesianProduct testCases)
+  for testCase in testCases
     do ({size, unsigned, bigEndian, offset} = testCase) ->
       it "should not throw RangeError when reading up to the length for #{JSON.stringify testCase}", ->
         buf = new Buffer (offset ? 0) + size

--- a/test/spec-helper.coffee
+++ b/test/spec-helper.coffee
@@ -1,1 +1,26 @@
 global.SRC = "#{__dirname}/../src"
+
+# cartesianProduct takes an object of arrays and creates an array of objects
+# with every combination of values from each array.
+# example:
+# cartesianProduct({ a: [1,2,3], b: [false, true] })
+# -> [ { a: 1, b: false },
+#      { a: 1, b: true  },
+#      { a: 2, b: false },
+#      { a: 2, b: true  },
+#      { a: 3, b: false },
+#      { a: 3, b: true  } ]
+cartesianProduct = (arg) ->
+  acc = [{}]
+  for own key, xs of arg
+    acc_ = []
+    for a in acc
+      for x in xs
+        r = Object.assign {}, a
+        r[key] = x
+        acc_.push r
+    acc = acc_
+  acc
+
+module.exports =
+  cartesianProduct: cartesianProduct


### PR DESCRIPTION
Related to http://jira.corpad.net.local:8080/browse/GMOON-728

Leading zeros in uint64 and int64 are treated as octal numbers. Note that smaller integers do not have this behaviour.

This changeset ensures that leading zeros in numbers are ignored.

e.g. "0123" should be written identically to "123"