### PR TITLE
Fix for throwing error when trying to write a 64-bit integer using a number.

### DIFF
--- a/src/clever-buffer-writer.coffee
+++ b/src/clever-buffer-writer.coffee
@@ -49,6 +49,10 @@ class CleverBufferWriter extends CleverBuffer
     offset = _offset ? @offset
     # ref treats leading zeros as denoting octal numbers, so we want to strip
     # them out to prevent this behaviour
+    if typeof value is 'number'
+      value = value.toString()
+    if not @noAssert and not /^\d+$/.test value
+      throw new TypeError '"value" argument is out of bounds'
     value = value.replace /^0+(\d)/, '$1'
     if @bigEndian
       ref.writeUInt64BE(@buffer, offset, value)
@@ -58,6 +62,10 @@ class CleverBufferWriter extends CleverBuffer
 
   writeInt64: (value, _offset) ->
     offset = _offset ? @offset
+    if typeof value is 'number'
+      value = value.toString()
+    if not @noAssert and not /^-?\d+$/.test value
+      throw new TypeError '"value" argument is out of bounds'
     # ref treats leading zeros as denoting octal numbers, so we want to strip
     # them out to prevent this behaviour.
     # Also, ref treats '-0123' as a negative octal

--- a/test/clever-buffer-writer.spec.coffee
+++ b/test/clever-buffer-writer.spec.coffee
@@ -4,7 +4,7 @@ CleverBufferWriter       = require "#{SRC}/clever-buffer-writer"
   writeToCleverBuffer }  = require './support/test-helper'
 specHelper               = require './spec-helper'
 
-describe 'CleverBuffer', ->
+describe 'CleverBufferWriter', ->
 
   NUMBER_OF_ITERATIONS = 16
 
@@ -304,7 +304,7 @@ describe 'CleverBuffer', ->
     buf = new Buffer 8
     buf.fill 0
     cleverBuffer = new CleverBufferWriter buf
-    cleverBuffer.writeUInt64('-1')
+    cleverBuffer.writeInt64('-1')
     cleverBuffer.getBuffer().should.eql new Buffer [
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     ]
@@ -313,7 +313,7 @@ describe 'CleverBuffer', ->
     buf = new Buffer 8
     buf.fill 0
     cleverBuffer = new CleverBufferWriter buf, {bigEndian:true}
-    cleverBuffer.writeUInt64('-1')
+    cleverBuffer.writeInt64('-1')
     cleverBuffer.getBuffer().should.eql new Buffer [
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     ]
@@ -352,32 +352,83 @@ describe 'CleverBuffer', ->
     cleverBuffer.writeUInt8(1)
     (-> cleverBuffer.writeUInt8(1)).should.throw()
 
-  testCases = specHelper.cartesianProduct
-    size:      [1, 2, 4, 8]
-    unsigned:  [false]
-    bigEndian: [false, true]
+  describe 'leading zeros are handling correctly', ->
+    for testCase in specHelper.cartesianProduct {
+      size:      [1, 2, 4, 8]
+      unsigned:  [false, true]
+      bigEndian: [false, true]
+    }
+      do ({size, unsigned, bigEndian} = testCase) ->
+        it "should correctly handle leading zero for #{JSON.stringify testCase}", ->
+          buf1 = new Buffer size
+          buf2 = new Buffer size
 
-  for testCase in testCases
-    do ({size, unsigned, bigEndian} = testCase) ->
-      it "should correctly handle leading zero for #{JSON.stringify testCase}", ->
-        buf1 = new Buffer size
-        buf2 = new Buffer size
+          cleverBuffer1 = new CleverBufferWriter buf1,
+            bigEndian: bigEndian
+            noAssert: false
 
-        cleverBuffer1 = new CleverBufferWriter buf1,
-          bigEndian: bigEndian
-          noAssert: false
+          cleverBuffer2 = new CleverBufferWriter buf2,
+            bigEndian: bigEndian
+            noAssert: false
 
-        cleverBuffer2 = new CleverBufferWriter buf2,
-          bigEndian: bigEndian
-          noAssert: false
+          if unsigned
+            f = "writeUInt#{size*8}"
+            cleverBuffer1[f] "123"
+            cleverBuffer2[f] "00123"
+          else
+            f = "writeInt#{size*8}"
+            cleverBuffer1[f] "-123"
+            cleverBuffer2[f] "-00123"
 
-        if unsigned
-          f = "writeUInt#{size*8}"
-          cleverBuffer1[f] "123"
-          cleverBuffer2[f] "00123"
-        else
-          f = "writeInt#{size*8}"
-          cleverBuffer1[f] "-123"
-          cleverBuffer2[f] "-00123"
+          buf1.should.eql buf2
 
-        buf1.should.eql buf2
+  describe 'check we handle numbers and strings identically', ->
+    for testCase in specHelper.cartesianProduct {
+      size:      [1, 2, 4, 8]
+      unsigned:  [false, true]
+      bigEndian: [false, true]
+    }
+      do ({size, unsigned, bigEndian} = testCase) ->
+        it "should correctly handle numbers and strings for #{JSON.stringify testCase}", ->
+          buf1 = new Buffer size
+          buf2 = new Buffer size
+
+          cleverBuffer1 = new CleverBufferWriter buf1,
+            bigEndian: bigEndian
+            noAssert: false
+
+          cleverBuffer2 = new CleverBufferWriter buf2,
+            bigEndian: bigEndian
+            noAssert: false
+
+          if unsigned
+            f = "writeUInt#{size*8}"
+            cleverBuffer1[f] "123"
+            cleverBuffer2[f] 123
+          else
+            f = "writeInt#{size*8}"
+            cleverBuffer1[f] "-123"
+            cleverBuffer2[f] -123
+
+          buf1.should.eql buf2
+
+  describe 'check only throwing exception for writing negative unsigned integers when noAssert:false', ->
+    for testCase in specHelper.cartesianProduct {
+      size:      [1, 2, 4, 8]
+      bigEndian: [false, true]
+    }
+      do ({size, bigEndian} = testCase) ->
+        it "should throw for noAssert:false #{JSON.stringify testCase}", ->
+          cleverBuffer = new CleverBufferWriter (new Buffer size),
+            bigEndian: bigEndian
+            noAssert: false
+          (-> cleverBuffer["writeUInt#{size*8}"]("-1")).should.throw(TypeError)
+          (-> cleverBuffer["writeUInt#{size*8}"](-1)).should.throw(TypeError)
+
+        it "should not throw for noAssert:true #{JSON.stringify testCase}", ->
+          buf = new Buffer size
+          cleverBuffer = new CleverBufferWriter buf,
+            bigEndian: bigEndian
+            noAssert: true
+          (-> cleverBuffer["writeUInt#{size*8}"]("-1")).should.not.throw()
+          (-> cleverBuffer["writeUInt#{size*8}"](-1)).should.not.throw()


### PR DESCRIPTION
My previous change assumed that 64-bit integers were passed as strings. It introduced an issue where an exception was thrown if passed a number.

This changeset fixes that issue. It also ensues that writing a negative number as an unsigned 64-bit number throws an error -- as it does for other sized integers.

I've also included comprehensive unit tests for these cases.